### PR TITLE
Fix Type.has method

### DIFF
--- a/Truth/Core/Phases/Type/Type.ts
+++ b/Truth/Core/Phases/Type/Type.ts
@@ -648,7 +648,7 @@ export class Type
 		for (const containedType of this.contents)
 			if (type.name === containedType.name)
 				for (const parallel of containedType.iterate(t => t.parallels))
-					if (parallel.type === containedType)
+					if (parallel.type === type)
 						return true;
 		
 		return false;


### PR DESCRIPTION
The current implementation for `Type.has` was producing wrong results for the following Truth file:

```truth
C
B
A:
  B: C
```
running the following JavaScript code must produce `false` while it was producing `true`.

```js
doc.query("A").has(doc.query("B"))
```